### PR TITLE
using the lock_api to generalize Talck

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,12 @@ exclude = [
 
 
 [features]
-allocator = ["spin"]
-spin = ["spin_crate", "lock_api"]
-default = ["spin", "allocator"]
+allocator = ["lock_api"]
+default = ["allocator"]
 
 
 [dependencies]
 lock_api = { version= "0.4", optional = true }
-spin_crate = { package = "spin", version = "0.9.8", default-features = false, features = ["lock_api", "spin_mutex"], optional = true }
 
 [dev-dependencies]
 simple-chunk-allocator = "0.1.5"
@@ -32,7 +30,7 @@ good_memory_allocator = { version = "0.1.7", features = ["spin", "allocator"] }
 average = "0.13.1"
 fastrand = "1.9.0"
 tikv-jemallocator = { version = "0.5.0", features = [] }
-
+spin = { version = "0.9.8", default-features = false, features = ["lock_api", "spin_mutex"] }
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,13 @@ exclude = [
 
 [features]
 allocator = ["spin"]
+spin = ["spin_crate", "lock_api"]
 default = ["spin", "allocator"]
 
 
 [dependencies]
-spin = { version = "0.9.4", optional = true }
+lock_api = { version= "0.4", optional = true }
+spin_crate = { package = "spin", version = "0.9.8", default-features = false, features = ["lock_api", "spin_mutex"], optional = true }
 
 [dev-dependencies]
 simple-chunk-allocator = "0.1.5"

--- a/examples/galloc_allocator_bench.rs
+++ b/examples/galloc_allocator_bench.rs
@@ -34,7 +34,7 @@ use std::{
 };
 
 use average::Mean;
-use spin::Barrier;
+use spin_crate::Barrier;
 
 const CHUNKS_AMOUNT: usize = 1 << 23;
 const CHUNK_SIZE: usize = 64;
@@ -59,14 +59,14 @@ const MAX_MILLIS_AMOUNT: usize = TIME_STEP_MILLIS * TIME_STEPS_AMOUNT;
 pub struct GlobalChunkAllocator<
     'a,
     const CHUNK_SIZE: usize = { simple_chunk_allocator::DEFAULT_CHUNK_SIZE },
->(spin::Mutex<simple_chunk_allocator::ChunkAllocator<'a, CHUNK_SIZE>>);
+>(spin_crate::Mutex<simple_chunk_allocator::ChunkAllocator<'a, CHUNK_SIZE>>);
 
 impl<'a, const CHUNK_SIZE: usize> GlobalChunkAllocator<'a, CHUNK_SIZE> {
     #[inline]
     pub const fn new(heap: &'a mut [u8], bitmap: &'a mut [u8]) -> Self {
         let inner_alloc =
             simple_chunk_allocator::ChunkAllocator::<CHUNK_SIZE>::new_const(heap, bitmap);
-        Self(spin::Mutex::new(inner_alloc))
+        Self(spin_crate::Mutex::new(inner_alloc))
     }
 }
 
@@ -127,7 +127,7 @@ macro_rules! allocator_list {
     }
 }
 
-static mut TALC_ALLOCATOR: talc::Talck = talc::Talc::new().spin_lock();
+static mut TALC_ALLOCATOR: talc::Talck<spin_crate::Mutex<()>> = talc::Talc::new().spin_lock();
 static mut GALLOC_ALLOCATOR: good_memory_allocator::SpinLockedAllocator =
     good_memory_allocator::SpinLockedAllocator::empty();
 static LINKED_LIST_ALLOCATOR: linked_list_allocator::LockedHeap =

--- a/examples/galloc_allocator_bench.rs
+++ b/examples/galloc_allocator_bench.rs
@@ -34,7 +34,7 @@ use std::{
 };
 
 use average::Mean;
-use spin_crate::Barrier;
+use spin::Barrier;
 
 const CHUNKS_AMOUNT: usize = 1 << 23;
 const CHUNK_SIZE: usize = 64;
@@ -59,14 +59,14 @@ const MAX_MILLIS_AMOUNT: usize = TIME_STEP_MILLIS * TIME_STEPS_AMOUNT;
 pub struct GlobalChunkAllocator<
     'a,
     const CHUNK_SIZE: usize = { simple_chunk_allocator::DEFAULT_CHUNK_SIZE },
->(spin_crate::Mutex<simple_chunk_allocator::ChunkAllocator<'a, CHUNK_SIZE>>);
+>(spin::Mutex<simple_chunk_allocator::ChunkAllocator<'a, CHUNK_SIZE>>);
 
 impl<'a, const CHUNK_SIZE: usize> GlobalChunkAllocator<'a, CHUNK_SIZE> {
     #[inline]
     pub const fn new(heap: &'a mut [u8], bitmap: &'a mut [u8]) -> Self {
         let inner_alloc =
             simple_chunk_allocator::ChunkAllocator::<CHUNK_SIZE>::new_const(heap, bitmap);
-        Self(spin_crate::Mutex::new(inner_alloc))
+        Self(spin::Mutex::new(inner_alloc))
     }
 }
 
@@ -127,7 +127,7 @@ macro_rules! allocator_list {
     }
 }
 
-static mut TALC_ALLOCATOR: talc::Talck<spin_crate::Mutex<()>> = talc::Talc::new().spin_lock();
+static mut TALC_ALLOCATOR: talc::Talck<spin::Mutex<()>> = talc::Talc::new().spin_lock();
 static mut GALLOC_ALLOCATOR: good_memory_allocator::SpinLockedAllocator =
     good_memory_allocator::SpinLockedAllocator::empty();
 static LINKED_LIST_ALLOCATOR: linked_list_allocator::LockedHeap =

--- a/examples/simple_chunk_allocator_bench.rs
+++ b/examples/simple_chunk_allocator_bench.rs
@@ -29,7 +29,7 @@ SOFTWARE.
 
 use good_memory_allocator::DEFAULT_SMALLBINS_AMOUNT;
 use simple_chunk_allocator::{GlobalChunkAllocator, DEFAULT_CHUNK_SIZE};
-use talc::Talc;
+use talc::{Talc, Talck};
 
 use std::alloc::{Allocator, Layout};
 use std::time::Instant;
@@ -70,7 +70,7 @@ fn main() {
     }
     let bench_galloc = benchmark_allocator(&mut galloc_allocator);
 
-    let talc = Talc::new().spin_lock();
+    let talc: Talck<spin_crate::Mutex<()>> = Talc::new().spin_lock();
     unsafe {
         talc.0.lock().init(HEAP_MEMORY.0.as_mut_ptr_range().into());
     }

--- a/examples/simple_chunk_allocator_bench.rs
+++ b/examples/simple_chunk_allocator_bench.rs
@@ -70,7 +70,7 @@ fn main() {
     }
     let bench_galloc = benchmark_allocator(&mut galloc_allocator);
 
-    let talc: Talck<spin_crate::Mutex<()>> = Talc::new().spin_lock();
+    let talc: Talck<spin::Mutex<()>> = Talc::new().spin_lock();
     unsafe {
         talc.0.lock().init(HEAP_MEMORY.0.as_mut_ptr_range().into());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1047,8 +1047,8 @@ impl Talc {
     /// This implements the `GlobalAlloc` trait and provides
     /// access to the `Allocator` API.
     #[cfg(feature = "spin")]
-    pub const fn spin_lock(self) -> Talck {
-        Talck(spin::Mutex::new(self))
+    pub const fn spin_lock(self) -> Talck<spin_crate::Mutex<()>> {
+        Talck(spin_crate::lock_api::Mutex::new(self))
     }
 
     /// Debugging function for checking various assumptions.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,16 +12,16 @@
 #![cfg_attr(feature = "allocator", feature(allocator_api))]
 #![feature(maybe_uninit_uninit_array)]
 
-#[cfg(feature = "spin")]
+#[cfg(feature = "lock_api")]
 mod talck;
 
 mod llist;
 mod span;
 mod tag;
 
-#[cfg(feature = "spin")]
+#[cfg(feature = "lock_api")]
 pub use talck::Talck;
-#[cfg(all(feature = "spin", feature = "allocator"))]
+#[cfg(all(feature = "lock_api", feature = "allocator"))]
 pub use talck::TalckRef;
 
 use llist::LlistNode;
@@ -1046,7 +1046,7 @@ impl Talc {
     ///
     /// This implements the `GlobalAlloc` trait and provides
     /// access to the `Allocator` API.
-    #[cfg(feature = "spin")]
+    #[cfg(feature = "lock_api")]
     pub const fn spin_lock<R: lock_api::RawMutex>(self) -> Talck<R> {
         Talck(lock_api::Mutex::new(self))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1047,8 +1047,8 @@ impl Talc {
     /// This implements the `GlobalAlloc` trait and provides
     /// access to the `Allocator` API.
     #[cfg(feature = "spin")]
-    pub const fn spin_lock(self) -> Talck<spin_crate::Mutex<()>> {
-        Talck(spin_crate::lock_api::Mutex::new(self))
+    pub const fn spin_lock<R: lock_api::RawMutex>(self) -> Talck<R> {
+        Talck(lock_api::Mutex::new(self))
     }
 
     /// Debugging function for checking various assumptions.


### PR DESCRIPTION
By using the `lock_api` the `spin::Mutex` in Talck can be replaced by any other lock implementation. 