### PR TITLE
docs: Example (Global Allocator) - Revised comments

### DIFF
--- a/examples/std_global_allocator.rs
+++ b/examples/std_global_allocator.rs
@@ -7,14 +7,15 @@ use talc::*;
 static mut START_ARENA: [u8; 10000] = [0; 10000];
 
 #[global_allocator]
-// the mutex provided by the `spin` crate is used here as it's a sensible choice
+// The mutex provided by the `spin` crate is used here as it's a sensible choice
 static ALLOCATOR: Talck<spin::Mutex<()>, ClaimOnOom> =
-    // we need to use the ClaimOnOom OOM handler or similar as allocations may
-    // occur prior to invocation of the program entrypoint main(), so claiming some
-    // memory must be done on-demand
+    // An OOM handler such as ClaimOnOom is required, as allocations
+    // may occur prior to invoking the program entrypoint `main()`,
+    // thus needs to support claiming memory on demand
     Talc::new(unsafe { ClaimOnOom::new(
         Span::from_base_size(&START_ARENA as *const _ as *mut _, 10000)
-        // Span::from_array(&mut ARENA) - better but requires unstable #[feature(const_mut_refs)]
+        // A better alternative, but requires the unstable attribute #[feature(const_mut_refs)]
+        // Span::from_array(&mut START_ARENA)
     ) }).lock();
 
 fn main() {

--- a/examples/std_global_allocator.rs
+++ b/examples/std_global_allocator.rs
@@ -9,9 +9,8 @@ static mut START_ARENA: [u8; 10000] = [0; 10000];
 #[global_allocator]
 // The mutex provided by the `spin` crate is used here as it's a sensible choice
 static ALLOCATOR: Talck<spin::Mutex<()>, ClaimOnOom> =
-    // An OOM handler such as ClaimOnOom is required, as allocations
-    // may occur prior to invoking the program entrypoint `main()`,
-    // thus needs to support claiming memory on demand
+    // Allocations may occur prior to the execution of `main()`, thus support for 
+    // claiming memory on-demand is required, such as the ClaimOnOom OOM handler.
     Talc::new(unsafe { ClaimOnOom::new(
         Span::from_base_size(&START_ARENA as *const _ as *mut _, 10000)
         // A better alternative, but requires the unstable attribute #[feature(const_mut_refs)]


### PR DESCRIPTION
Just a little bit of revision if you like the phrasing any better.

Main motivation was the `Span::from_array` comment.
- It looks like the variable needed to be updated and the associated comment could better communicate the alternative with two lines.
- For some reason it didn't catch my attention [when you originally suggested it](https://github.com/SFBdragon/talc/issues/18#issuecomment-1819499471).