### PR TITLE
Added new WASM benchmark for talc with a static backing array as heap

### DIFF
--- a/wasm-bench.sh
+++ b/wasm-bench.sh
@@ -6,15 +6,20 @@
 cd wasm-bench
 
 echo "talc"
-wasm-pack --log-level warn build --release --quiet --target web --features talc
+rustup run nightly wasm-pack --log-level warn build --release --quiet --target web --features talc
+deno run --allow-read bench.js
+
+echo ""
+echo "talc (static)"
+rustup run nightly wasm-pack --log-level warn build --release --quiet --target web --features talc_static
 deno run --allow-read bench.js
 
 echo ""
 echo "dlmalloc (default)"
-wasm-pack --log-level warn build --release --quiet --target web
+rustup run nightly wasm-pack --log-level warn build --release --quiet --target web
 deno run --allow-read bench.js
 
 echo ""
 echo "lol_alloc"
-wasm-pack --log-level warn build --release --quiet --target web --features lol_alloc
+rustup run nightly wasm-pack --log-level warn build --release --quiet --target web --features lol_alloc
 deno run --allow-read bench.js

--- a/wasm-bench.sh
+++ b/wasm-bench.sh
@@ -6,20 +6,20 @@
 cd wasm-bench
 
 echo "talc"
-rustup run nightly wasm-pack --log-level warn build --release --quiet --target web --features talc
+wasm-pack --log-level warn build --release --quiet --target web --features talc
 deno run --allow-read bench.js
 
 echo ""
 echo "talc (static ClaimOnOom)"
-rustup run nightly wasm-pack --log-level warn build --release --quiet --target web --features talc_claim_oom
+wasm-pack --log-level warn build --release --quiet --target web --features talc_claim_oom
 deno run --allow-read bench.js
 
 echo ""
 echo "dlmalloc (default)"
-rustup run nightly wasm-pack --log-level warn build --release --quiet --target web
+wasm-pack --log-level warn build --release --quiet --target web
 deno run --allow-read bench.js
 
 echo ""
 echo "lol_alloc"
-rustup run nightly wasm-pack --log-level warn build --release --quiet --target web --features lol_alloc
+wasm-pack --log-level warn build --release --quiet --target web --features lol_alloc
 deno run --allow-read bench.js

--- a/wasm-bench.sh
+++ b/wasm-bench.sh
@@ -10,8 +10,8 @@ rustup run nightly wasm-pack --log-level warn build --release --quiet --target w
 deno run --allow-read bench.js
 
 echo ""
-echo "talc (static)"
-rustup run nightly wasm-pack --log-level warn build --release --quiet --target web --features talc_static
+echo "talc (static ClaimOnOom)"
+rustup run nightly wasm-pack --log-level warn build --release --quiet --target web --features talc_claim_oom
 deno run --allow-read bench.js
 
 echo ""

--- a/wasm-bench/Cargo.toml
+++ b/wasm-bench/Cargo.toml
@@ -28,3 +28,6 @@ wasm-bindgen-test = "0.3.34"
 # be realistic about the optimization configuration, even if it's a benchmark
 [profile.release]
 opt-level = "z"
+
+[features]
+talc_static = ["talc"]

--- a/wasm-bench/Cargo.toml
+++ b/wasm-bench/Cargo.toml
@@ -30,4 +30,4 @@ wasm-bindgen-test = "0.3.34"
 opt-level = "z"
 
 [features]
-talc_static = ["talc"]
+talc_claim_oom = ["talc"]

--- a/wasm-bench/src/lib.rs
+++ b/wasm-bench/src/lib.rs
@@ -3,16 +3,17 @@ use std::alloc::Layout;
 use wasm_bindgen::prelude::*;
 
 
-#[cfg(all(feature = "talc", not(feature = "talc_static")))]
+#[cfg(all(feature = "talc", not(feature = "talc_claim_oom")))]
 #[global_allocator]
 static TALCK: talc::TalckWasm = unsafe { talc::TalckWasm::new_global() };
 
-#[cfg(feature = "talc_static")]
+#[cfg(feature = "talc_claim_oom")]
 #[global_allocator]
 static ALLOCATOR: talc::Talck<talc::locking::AssumeUnlockable, talc::ClaimOnOom> = {
-    static mut MEMORY: [std::mem::MaybeUninit<u8>; 64 * 1024 * 1024] =
-        [std::mem::MaybeUninit::uninit(); 64 * 1024 * 1024];
-    let span = talc::Span::from_base_size(unsafe { MEMORY.as_ptr() as *mut _ }, 64 * 1024 * 1024);
+    const MEMORY_SIZE: usize = 32 * 1024 * 1024;
+    static mut MEMORY: [std::mem::MaybeUninit<u8>; MEMORY_SIZE] =
+        [std::mem::MaybeUninit::uninit(); MEMORY_SIZE];
+    let span = talc::Span::from_base_size(unsafe { MEMORY.as_ptr() as *mut _ }, MEMORY_SIZE);
     talc::Talc::new(unsafe { talc::ClaimOnOom::new(span) }).lock()
 };
 

--- a/wasm-size.sh
+++ b/wasm-size.sh
@@ -5,15 +5,20 @@
 cd wasm-size
 
 echo "talc"
-cargo build --quiet --release --target wasm32-unknown-unknown
+cargo +nightly build --quiet --release --target wasm32-unknown-unknown
+wc -c ./target/wasm32-unknown-unknown/release/wasm_size.wasm
+
+echo ""
+echo "talc (static)"
+cargo +nightly build --quiet --release --target wasm32-unknown-unknown --features talc_static
 wc -c ./target/wasm32-unknown-unknown/release/wasm_size.wasm
 
 echo ""
 echo "dlmalloc (default)"
-cargo build --quiet --release --target wasm32-unknown-unknown --features dlmalloc
+cargo +nightly build --quiet --release --target wasm32-unknown-unknown --features dlmalloc
 wc -c ./target/wasm32-unknown-unknown/release/wasm_size.wasm
 
 echo ""
 echo "lol_alloc"
-cargo build --quiet --release --target wasm32-unknown-unknown --features lol_alloc
+cargo +nightly build --quiet --release --target wasm32-unknown-unknown --features lol_alloc
 wc -c ./target/wasm32-unknown-unknown/release/wasm_size.wasm

--- a/wasm-size.sh
+++ b/wasm-size.sh
@@ -5,20 +5,20 @@
 cd wasm-size
 
 echo "talc"
-cargo +nightly build --quiet --release --target wasm32-unknown-unknown
+cargo build --quiet --release --target wasm32-unknown-unknown
 wc -c ./target/wasm32-unknown-unknown/release/wasm_size.wasm
 
 echo ""
 echo "talc (static)"
-cargo +nightly build --quiet --release --target wasm32-unknown-unknown --features talc_static
+cargo build --quiet --release --target wasm32-unknown-unknown --features talc_static
 wc -c ./target/wasm32-unknown-unknown/release/wasm_size.wasm
 
 echo ""
 echo "dlmalloc (default)"
-cargo +nightly build --quiet --release --target wasm32-unknown-unknown --features dlmalloc
+cargo build --quiet --release --target wasm32-unknown-unknown --features dlmalloc
 wc -c ./target/wasm32-unknown-unknown/release/wasm_size.wasm
 
 echo ""
 echo "lol_alloc"
-cargo +nightly build --quiet --release --target wasm32-unknown-unknown --features lol_alloc
+cargo build --quiet --release --target wasm32-unknown-unknown --features lol_alloc
 wc -c ./target/wasm32-unknown-unknown/release/wasm_size.wasm

--- a/wasm-size/Cargo.toml
+++ b/wasm-size/Cargo.toml
@@ -19,6 +19,7 @@ features = ["lock_api"]
 
 [features]
 default = []
+talc_static = []
 
 [profile.release]
 opt-level = "z"


### PR DESCRIPTION
Added setting to run `wasm-pack build` in nightly, due to unstable feature errors when using stable. Also added a new benchmark for WASM, using `ClaimOnOom` plus a static array instead of relying on `grow_memory`.