### PR TITLE
docs: Revise notes for example `std_global_allocator.rs`

### DIFF
--- a/stable_examples/examples/std_global_allocator.rs
+++ b/stable_examples/examples/std_global_allocator.rs
@@ -3,7 +3,7 @@ use talc::*;
 // note:
 // - Miri thinks this violates stacked borrows upon program termination.
 //   - This only occurs with `#[global_allocator]`.
-//   - Use the allocator API if you can't have that. Perhaps check out `examples/stable_allocator_api.rs`?
+//   - Consider using the allocator API if you can't have that (see: `examples/stable_allocator_api.rs`)
 // - `spin::Mutex<()>`
 //   The `spin` crate provides a mutex that is a sensible choice to use.
 // - `ClaimOnOom`
@@ -14,7 +14,7 @@ static mut START_ARENA: [u8; 10000] = [0; 10000];
 
 #[global_allocator]
 static ALLOCATOR: Talck<spin::Mutex<()>, ClaimOnOom> = Talc::new(unsafe {
-    ClaimOnOom::new(Span::from_const_array(std::ptr::addr_of!(START_ARENA)))
+    ClaimOnOom::new(Span::from_const_array(core::ptr::addr_of!(START_ARENA)))
 }).lock();
 
 fn main() {


### PR DESCRIPTION
I noticed a recent commit hoisted the two type comments from their contextual proximity to relevant code, while the `START_ARENA` line seems to have no relevance separating the two comment sections. Grouped them together as bullet point notes.

The two type focused comments are more explicit about communicating that early now, followed by the description for the choice (_it's not really communicated why `spin::Mutex` is sensible to the user, but I suppose that's better context than none_). Was vaguely touched on [here](https://github.com/SFBdragon/talc/issues/18#issuecomment-1817777442), I could add a link to that for reference if considered helpful?

It's not clear what the Miri comment refers to by "this", other than the relation to the global allocator attribute. Nor what "if you can't have that" is referring to (_the violation being potentially valid, or a false-positive from Miri?_). Additionally corrected a typo + corrected the file name that was changed since the comment was written.

The [shorter README equivalent](https://github.com/SFBdragon/talc#setup) uses `ARENA` instead of `START_ARENA`, was `START_` meant to communicate any additional context?
- This isn't an area of expertise for me, so while it might not matter to someone more familiar, for a newbie however there might be some benefit in adding context.
- [Your response in this PR](https://github.com/SFBdragon/talc/pull/34#issuecomment-2254108619) mentions multiple arena's, so I guess the intent of `START_` is an initial arena.