### PR TITLE
docs(README): Replace relative paths with absolute URLs

### DIFF
--- a/talc/README.md
+++ b/talc/README.md
@@ -24,7 +24,7 @@
 
 ## Table of Contents
 
-Targeting WebAssembly? You can find WASM-specific usage and benchmarks [here](./README_WASM.md).
+Targeting WebAssembly? You can find WASM-specific usage and benchmarks [here](https://github.com/SFBdragon/talc/README_WASM.md).
 
 - [Setup](#setup)
 - [Benchmarks](#benchmarks)
@@ -98,15 +98,15 @@ The number of successful allocations, deallocations, and reallocations within th
 
 #### 1 Thread
 
-![Random Actions Benchmark Results](./benchmark_graphs/random_actions.png)
+![Random Actions Benchmark Results](https://github.com/SFBdragon/talc/benchmark_graphs/random_actions.png)
 
 #### 4 Threads
 
-![Random Actions Multi Benchmark Results](./benchmark_graphs/random_actions_multi.png)
+![Random Actions Multi Benchmark Results](https://github.com/SFBdragon/talc/benchmark_graphs/random_actions_multi.png)
 
 ## Allocations & Deallocations Microbenchmark
 
-![Microbenchmark Results](./benchmark_graphs/microbench.png)
+![Microbenchmark Results](https://github.com/SFBdragon/talc/benchmark_graphs/microbench.png)
 
 Label indicates the maximum within 50 standard deviations from the median. Max allocation size is 0x10000.
 
@@ -319,7 +319,7 @@ To migrate from v2 to v3, keep in mind that you must keep track of the heaps if 
 #### v2.2.0
 - Added `dlmalloc` to the benchmarks.
 - WASM should now be fully supported via `TalckWasm`. Let me know what breaks ;)
-    - Find more details [here](./README_WASM.md).
+    - Find more details [here](https://github.com/SFBdragon/talc/README_WASM.md).
 
 
 #### v2.1.0


### PR DESCRIPTION
The default repo page presently renders broken benchmark graph images since the relative paths are not valid from this location (_you'd have to symlink the related directory I guess?_).

This also makes the WASM symlink probably not that useful, unless you're utilizing it somewhere else? Potentially consider a minimal README that links to the detailed talc subdir README, along with mention of the related dedicated WASM one? May be better than the symlink approach.

---

I'm not sure how you're using the relative links with the symlinks, but at least via the Web UI on Github, only the README in the main repo page is rendering the symlink, while directly viewing the `README.md` is similar to the [early linked WASM symlink which just renders the symlink path](https://github.com/SFBdragon/talc/blob/https://github.com/SFBdragon/talc/commit/d851fd1d60f17f699351cdf36ff808cb08a108cf/README_WASM.md).

Side-note: You don't appear to use git tags in this repo to align with the tagged commits for your crate releases? That might be worth considering in future as a good practice (_so the link I used above is to the latest repo commit_).