### PR TITLE
Support fallible malloc attempts without OOM handling

### DIFF
--- a/talc/src/span.rs
+++ b/talc/src/span.rs
@@ -1,4 +1,8 @@
-use core::ops::Range;
+use core::{
+    hash::{Hash, Hasher},
+    ops::Range,
+    ptr::null_mut,
+};
 
 use crate::ptr_utils::*;
 
@@ -11,7 +15,7 @@ use crate::ptr_utils::*;
 /// the specific values of `base` and `acme` are considered meaningless.
 /// * Empty spans contain nothing and overlap with nothing.
 /// * Empty spans are contained by any sized span.
-#[derive(Clone, Copy, Hash)]
+#[derive(Clone, Copy)]
 pub struct Span {
     base: *mut u8,
     acme: *mut u8,
@@ -120,10 +124,23 @@ impl<T, const N: usize> From<*const [T; N]> for Span {
 
 impl PartialEq for Span {
     fn eq(&self, other: &Self) -> bool {
-        self.is_empty() && other.is_empty() || self.base == other.base && self.acme == other.acme
+        self.is_empty() && other.is_empty()
+            || core::ptr::eq(self.base, other.base) && core::ptr::eq(self.acme, other.acme)
     }
 }
 impl Eq for Span {}
+
+impl Hash for Span {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        if self.is_empty() {
+            null_mut::<u8>().hash(hasher);
+            null_mut::<u8>().hash(hasher);
+        } else {
+            self.base.hash(hasher);
+            self.acme.hash(hasher);
+        }
+    }
+}
 
 impl Span {
     /// Returns whether `base >= acme`.

--- a/talc/src/talc.rs
+++ b/talc/src/talc.rs
@@ -322,9 +322,31 @@ impl<O: OomHandler> Talc<O> {
     }
 
     /// Allocate a contiguous region of memory according to `layout`, if possible.
+    /// If the allocation is not currently possible, attempt to recover via the
+    /// specified [`OomHandler`].
+    /// See [`Self::malloc_without_oom_handler`] for allocating without automatic OOM recovery.
+    ///
     /// # Safety
     /// `layout.size()` must be nonzero.
     pub unsafe fn malloc(&mut self, layout: Layout) -> Result<NonNull<u8>, ()> {
+        self.malloc_impl(layout, true)
+    }
+
+    /// Allocate a contiguous region of memory according to `layout`, if possible.
+    /// If the allocation is not currently possible, do not attempt to recover via
+    /// the specified [`OomHandler`] and always return `Err(())`.
+    ///
+    /// # Safety
+    /// `layout.size()` must be nonzero.
+    pub unsafe fn malloc_without_oom_handler(&mut self, layout: Layout) -> Result<NonNull<u8>, ()> {
+        self.malloc_impl(layout, false)
+    }
+
+    unsafe fn malloc_impl(
+        &mut self,
+        layout: Layout,
+        handle_oom: bool,
+    ) -> Result<NonNull<u8>, ()> {
         debug_assert!(layout.size() != 0);
         self.scan_for_errors();
 
@@ -332,7 +354,13 @@ impl<O: OomHandler> Talc<O> {
             // this returns None if there are no heaps or allocatable memory
             match self.get_sufficient_chunk(layout) {
                 Some(payload) => break payload,
-                None => _ = O::handle_oom(self, layout)?,
+                None => {
+                    if handle_oom {
+                        _ = O::handle_oom(self, layout)?
+                    } else {
+                        return Err(());
+                    }
+                }
             }
         };
 


### PR DESCRIPTION
When allocating with Talc for a balloon device allocations should be
multiples of 4KiB in size and must be aligned to 4KiB.
To reduce per-allocation overhead we want to group such allocations as
much as possible into large chunks.
Allocation of such almost as large as possible chunks below a maximum size
can be accomplished by attempting allocations in decreasing powers of
two below the maximum size.
These allocation attempts would however trigger the OOM handler which is
undesirable. The balloon driver is also responsible for OOM handling in
my case and since we are already within balloon driver code, making
these allocation attempts, the driver is already locked. The OOM handler
therefore cannot (and should not) deflate the balloon, because the
driver state is locked.
Thus we want to be able to make allocation attempts without triggering
the OOM handler.

This includes a drive-by fix for the derived `Hash` impl conflicting with the explicit `PartialEq` implementation of `Span`. They differed on equality for empty `Span`s AFAICT. 