### PR TITLE
fix insufficiently sized allocations for Wasm Sources

### DIFF
--- a/talc/src/wasm.rs
+++ b/talc/src/wasm.rs
@@ -120,14 +120,15 @@ unsafe impl crate::source::Source for WasmGrowAndClaim {
     ) -> Result<(), ()> {
         // Growth strategy: just try to grow enough to avoid OOM again on this allocation
         // Performance testing shows that it works well even in random actions.
-        let delta_pages = (layout.size() + crate::base::CHUNK_UNIT + (PAGE_SIZE - 1)) / PAGE_SIZE;
+        let requested_size = wasm_grow_request_size::<B>(talc.is_metadata_established(), layout);
+        let delta_pages = (requested_size + (PAGE_SIZE - 1)) / PAGE_SIZE;
 
         let prev_memory_end = match memory_grow::<0>(delta_pages) {
             usize::MAX => return Err(()),
             prev => prev,
         };
 
-        let grown_base = (prev_memory_end * PAGE_SIZE) as *mut u8;
+        let grown_base = wasm_pages_to_ptr(prev_memory_end);
         let grown_size = delta_pages * PAGE_SIZE;
 
         // This should always succeed. If it doesn't though, return Err(())
@@ -171,14 +172,15 @@ unsafe impl crate::source::Source for WasmGrowAndExtend {
         layout: core::alloc::Layout,
     ) -> Result<(), ()> {
         // growth strategy: just try to grow enough to avoid OOM again on this allocation
-        let delta_pages = (layout.size() + crate::base::CHUNK_UNIT + (PAGE_SIZE - 1)) / PAGE_SIZE;
+        let requested_size = wasm_grow_request_size::<B>(talc.is_metadata_established(), layout);
+        let delta_pages = (requested_size + (PAGE_SIZE - 1)) / PAGE_SIZE;
 
         let prev_memory_end = match memory_grow::<0>(delta_pages) {
             usize::MAX => return Err(()),
             prev => prev,
         };
 
-        let new_base = (prev_memory_end * PAGE_SIZE) as *mut u8;
+        let new_base = wasm_pages_to_ptr(prev_memory_end);
         let new_bytes = delta_pages * PAGE_SIZE;
         let new_end = ptr_utils::saturating_ptr_add(new_base, new_bytes);
 
@@ -199,6 +201,23 @@ unsafe impl crate::source::Source for WasmGrowAndExtend {
     }
 }
 
+#[inline]
+fn wasm_grow_request_size<B: Binning>(
+    metadata_established: bool,
+    layout: core::alloc::Layout,
+) -> usize {
+    // Account for the allocation itself, its alignment requirements, and internal heap alignment
+    // This mirrors the logic in GlobalAllocSource to ensure sufficient growth.
+    let mut requested_size = layout.size() + layout.align();
+    requested_size += crate::base::CHUNK_UNIT + crate::base::CHUNK_UNIT;
+
+    if !metadata_established {
+        requested_size += crate::min_first_heap_layout::<B>().size();
+    }
+
+    requested_size
+}
+
 /// WASM page size is 64KiB
 const PAGE_SIZE: usize = 1024 * 64;
 
@@ -209,4 +228,9 @@ use core::arch::wasm64::memory_grow;
 #[cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))]
 fn memory_grow<const M: usize>(_pages: usize) -> usize {
     panic!("not running on wasm32 or wasm64")
+}
+
+#[inline]
+fn wasm_pages_to_ptr(page_start: usize) -> *mut u8 {
+    (page_start * PAGE_SIZE) as *mut u8
 }


### PR DESCRIPTION
This PR fixes the insufficient sizing calculation for allocations very close to the page size in `Wasm` `Source`s leading to an infinite loop described in [the issue I just created](https://github.com/SFBdragon/talc/issues/47). The corrected sizing calculation mirrors the logic in `GlobalAllocSource`. It is calculated as `layout.size() + layout.align() + 2 * crate::base::CHUNK_UNIT`, which may not be the lowest correct size, like in `GlobalAllocSource` (see [this comment there](https://github.com/SFBdragon/talc/blob/b55d533df498d9e5c29ffecc71c0580d390c6fdd/talc/src/source/global_alloc.rs#L77)).

I have also created a separate branch including the same test from my issue, demonstrating that the buggy behaviour is fixed by this PR: https://github.com/COLORADIO-Project/talc/tree/demonstrate-fixed-wasm-sizing-calculation
The test can be run with `cargo test --target wasm32-wasip1`, which may require installing Wasmtime as the runner. I don't find the test code very readable, which is why I have not included it in this PR. I am happy to add it though, if desired.