### PR TITLE
Fix wasm heap corruption and runaway memory growth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,6 +69,12 @@ name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -111,7 +128,7 @@ checksum = "d9b5e0d321d61de16390ed273b647ce51605b575916d3c25e6ddf27a1e140035"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -152,6 +169,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20872400a6da150af7fd8036bc5b469397111fbf10f999238bae0308108d10a1"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,6 +222,12 @@ checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jemalloc-sys"
@@ -213,10 +260,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -236,6 +285,12 @@ dependencies = [
  "arbitrary",
  "cc",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -258,12 +313,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "log"
-version = "0.4.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
-
-[[package]]
 name = "lol_alloc"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +320,12 @@ checksum = "83e5106554cabc97552dcadf54f57560ae6af3276652f82ca2be06120dc4c5dc"
 dependencies = [
  "spin",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memory-stats"
@@ -292,10 +347,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "ppv-lite86"
@@ -378,16 +474,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "spin"
@@ -459,6 +613,7 @@ dependencies = [
  "lock_api",
  "spinning_top",
  "talc 5.0.3",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -485,6 +640,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,35 +660,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.100"
+name = "wasm-bindgen-futures"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -531,25 +693,64 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fde991ccdc895cb7fbaa14b137d62af74d9011be67b71c694bfc40edd3119c"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e925354648d2a4d1bf205412e36d520a800280622eef4719678d268e5d40e978"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684365b586a9a6256c1cc3544eee8680de48d6041142f581776ec7b139622ae9"
 
 [[package]]
 name = "wasm-perf"
@@ -578,12 +779,21 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -693,3 +903,9 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/talc/Cargo.toml
+++ b/talc/Cargo.toml
@@ -38,6 +38,9 @@ talc = { path = ".", features = ["error-scanning-std"] }
 spinning_top = "0.3"
 allocator-api2 = { version = "0.4", default-features = false, features = ["std"] }
 
+[target.'cfg(target_family = "wasm")'.dev-dependencies]
+wasm-bindgen-test = "0.3"
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/talc/src/base/chunk.rs
+++ b/talc/src/base/chunk.rs
@@ -14,7 +14,7 @@ pub(crate) fn is_chunk_size(base: *mut u8, end: *mut u8) -> bool {
 
 #[inline]
 pub(crate) const fn required_chunk_size(size: usize) -> usize {
-    (size + size_of::<Tag>() + (CHUNK_UNIT - 1)) & !(CHUNK_UNIT - 1)
+    (size + TAIL_SIZE + (CHUNK_UNIT - 1)) & !(CHUNK_UNIT - 1)
 }
 
 #[inline]
@@ -27,10 +27,16 @@ pub(crate) unsafe fn alloc_to_end(base: *mut u8, size: usize) -> *mut u8 {
 /// It may situationally take on other values in the future.
 pub const CHUNK_UNIT: usize = size_of::<usize>() * 4;
 
+/// Every chunk ends in a word-sized metadata slot: allocated chunks keep
+/// their [`Tag`] in its low byte, gaps fill it with their size and flags.
+/// A gap size's low bits are always zero, so the low byte distinguishes
+/// allocations from gaps no matter how large the gap is.
+pub(crate) const TAIL_SIZE: usize = size_of::<usize>();
+
 const GAP_NODE_OFFSET: usize = 0;
 const GAP_BIN_OFFSET: usize = size_of::<usize>() * 2;
 const GAP_LOW_SIZE_OFFSET: usize = size_of::<usize>() * 3;
-const GAP_HIGH_SIZE_OFFSET: usize = size_of::<usize>();
+const GAP_HIGH_SIZE_OFFSET: usize = TAIL_SIZE;
 
 pub const END_FLAG: usize = Tag::HEAP_END_FLAG as usize;
 
@@ -61,7 +67,7 @@ pub(crate) unsafe fn gap_node_to_size(node: NonNull<Node>) -> *mut usize {
 }
 #[inline]
 pub(crate) unsafe fn end_to_tag(end: *mut u8) -> *mut Tag {
-    end.sub(size_of::<Tag>()).cast()
+    end.sub(TAIL_SIZE).cast()
 }
 
 /// Aligns `ptr` up by `CHUNK_UNIT`.

--- a/talc/src/base/mod.rs
+++ b/talc/src/base/mod.rs
@@ -634,7 +634,7 @@ impl<S: Source, B: Binning> Talc<S, B> {
             heap_base = ptr_utils::align_up_by(base, align_of::<Option<NonNull<Node>>>());
 
             let gap_lists_size = size_of::<Option<NonNull<Node>>>() * B::BIN_COUNT as usize;
-            gap_base = align_up(heap_base.wrapping_add(gap_lists_size + size_of::<Tag>()));
+            gap_base = align_up(heap_base.wrapping_add(gap_lists_size + TAIL_SIZE));
 
             // if calculating gap_base overflowed OR the gap_base is higher than heap_end
             // there isn't enough memory to allocate the metadata and cap it off with a tag
@@ -655,7 +655,7 @@ impl<S: Source, B: Binning> Talc<S, B> {
         } else {
             // Note that adding the header size and aligning up automatically dodges
             // the possibility of claiming null, if `memory` started at null.
-            gap_base = align_up(base.wrapping_add(size_of::<Tag>()));
+            gap_base = align_up(base.wrapping_add(TAIL_SIZE));
 
             // if calculating gap_base overflowed OR there isn't a CHUNK_UNIT between
             // gap_base and heap_end, then there isn't enough memory to claim
@@ -1146,7 +1146,7 @@ mod tests {
                 assert!(gap_end <= gap_mem.cast::<u8>().add(gap_mem.len()));
                 assert!(gap_end.wrapping_add(CHUNK_UNIT) > gap_mem.cast::<u8>().add(gap_mem.len()));
 
-                let gap_base = align_up(gap_mem.cast::<u8>().add(size_of::<Tag>()));
+                let gap_base = align_up(gap_mem.cast::<u8>().add(TAIL_SIZE));
                 let gap_size = gap_end as usize - gap_base as usize;
                 assert!(gap_size <= 999);
                 assert!(999 - CHUNK_UNIT * 2 < gap_size);

--- a/talc/src/wasm.rs
+++ b/talc/src/wasm.rs
@@ -120,7 +120,7 @@ unsafe impl crate::source::Source for WasmGrowAndClaim {
     ) -> Result<(), ()> {
         // Growth strategy: just try to grow enough to avoid OOM again on this allocation
         // Performance testing shows that it works well even in random actions.
-        let delta_pages = (layout.size() + crate::base::CHUNK_UNIT + (PAGE_SIZE - 1)) / PAGE_SIZE;
+        let delta_pages = delta_pages_for(layout);
 
         let prev_memory_end = match memory_grow::<0>(delta_pages) {
             usize::MAX => return Err(()),
@@ -171,7 +171,7 @@ unsafe impl crate::source::Source for WasmGrowAndExtend {
         layout: core::alloc::Layout,
     ) -> Result<(), ()> {
         // growth strategy: just try to grow enough to avoid OOM again on this allocation
-        let delta_pages = (layout.size() + crate::base::CHUNK_UNIT + (PAGE_SIZE - 1)) / PAGE_SIZE;
+        let delta_pages = delta_pages_for(layout);
 
         let prev_memory_end = match memory_grow::<0>(delta_pages) {
             usize::MAX => return Err(()),
@@ -201,6 +201,19 @@ unsafe impl crate::source::Source for WasmGrowAndExtend {
 
 /// WASM page size is 64KiB
 const PAGE_SIZE: usize = 1024 * 64;
+
+/// Pages a claimed/extended heap needs to fit `layout`, accounting for the
+/// chunk's required size, claim overhead, and alignment padding. Undersizing
+/// this makes `allocate` acquire heaps that can never fit the allocation,
+/// looping until the wasm memory limit.
+fn delta_pages_for(layout: core::alloc::Layout) -> usize {
+    let mut required =
+        crate::base::chunk::required_chunk_size(layout.size()) + crate::base::CHUNK_UNIT;
+    if layout.align() > crate::base::CHUNK_UNIT {
+        required += layout.align();
+    }
+    (required + (PAGE_SIZE - 1)) / PAGE_SIZE
+}
 
 #[cfg(target_arch = "wasm32")]
 use core::arch::wasm32::memory_grow;

--- a/talc/tests/wasm_sources.rs
+++ b/talc/tests/wasm_sources.rs
@@ -1,0 +1,338 @@
+//! Regression tests for the WebAssembly sources. Run with:
+//! `CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner WASM_BINDGEN_TEST_ONLY_NODE=1 cargo test --target wasm32-unknown-unknown --test wasm_sources`
+#![cfg(all(target_family = "wasm", not(target_feature = "atomics")))]
+
+use core::alloc::{GlobalAlloc, Layout};
+
+use talc::base::Talc;
+use talc::cell::TalcCell;
+use talc::wasm::{WasmBinning, WasmGrowAndClaim, WasmGrowAndExtend};
+use wasm_bindgen_test::wasm_bindgen_test;
+
+fn memory_pages() -> usize {
+    core::arch::wasm32::memory_size::<0>()
+}
+
+struct Lcg(u64);
+
+impl Lcg {
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        self.0 >> 33
+    }
+
+    fn below(&mut self, n: u64) -> u64 {
+        self.next() % n
+    }
+}
+
+fn random_layout(rng: &mut Lcg) -> Layout {
+    let size = match rng.below(100) {
+        0..=64 => 1 + rng.below(4096) as usize,
+        65..=84 => 4096 + rng.below(61440) as usize,
+        85..=92 => (1 + rng.below(16) as usize) * 65536,
+        _ => 65536 + rng.below(2 * 1024 * 1024) as usize,
+    };
+    let align = 1 << rng.below(5);
+    Layout::from_size_align(size, align).unwrap()
+}
+
+fn fill(ptr: *mut u8, len: usize, pattern: u8) {
+    unsafe { core::ptr::write_bytes(ptr, pattern, len) }
+}
+
+#[track_caller]
+fn verify(ptr: *const u8, len: usize, pattern: u8) {
+    let buf = unsafe { core::slice::from_raw_parts(ptr, len) };
+    if let Some(pos) = buf.iter().position(|&b| b != pattern) {
+        panic!(
+            "heap corruption: {len}-byte allocation with pattern {pattern:#04x} \
+            contains {:#04x} at offset {pos}",
+            buf[pos]
+        );
+    }
+}
+
+/// `WasmGrowAndClaim` must not grow memory unboundedly around page-sized
+/// allocation boundaries: sizes just below a page multiple used to make
+/// `acquire` claim heaps that could never fit the allocation's required
+/// chunk size, looping until the wasm memory limit.
+#[wasm_bindgen_test]
+fn grow_and_claim_terminates_on_page_boundary_sizes() {
+    let mut talc = Talc::<_, WasmBinning>::new(WasmGrowAndClaim);
+
+    // prime: the first claim hosts the allocator metadata, so the
+    // allocations below go through subsequent claims
+    let prime = Layout::new::<u128>();
+    unsafe { talc.allocate(prime) }.unwrap();
+
+    for pages in 1..=4usize {
+        for size in [pages * 65536 - 16, pages * 65536] {
+            let before = memory_pages();
+            let layout = Layout::from_size_align(size, 1).unwrap();
+            let alloc = unsafe { talc.allocate(layout) };
+            let grown = memory_pages() - before;
+
+            assert!(alloc.is_some(), "allocation of {size} failed");
+            assert!(grown <= pages + 1, "grew {grown} pages for a {size}-byte allocation");
+
+            unsafe { talc.deallocate(alloc.unwrap().as_ptr(), layout) };
+        }
+    }
+}
+
+/// Like the above, but with varied small live allocations first, so the
+/// page-multiple request hits claims in assorted bin/gap states.
+#[wasm_bindgen_test]
+fn grow_and_claim_terminates_after_varied_priming() {
+    for seed in 0..50u64 {
+        let mut talc = Talc::<_, WasmBinning>::new(WasmGrowAndClaim);
+        let mut rng = Lcg(seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1);
+        let mut live = Vec::new();
+        for _ in 0..40 {
+            let layout =
+                Layout::from_size_align(1 + rng.below(4096) as usize, 1 << rng.below(4)).unwrap();
+            let ptr = unsafe { talc.allocate(layout) }.unwrap();
+            if rng.below(2) == 0 {
+                unsafe { talc.deallocate(ptr.as_ptr(), layout) };
+            } else {
+                live.push((ptr, layout));
+            }
+        }
+
+        let before = memory_pages();
+        let layout = Layout::from_size_align(65536, 1).unwrap();
+        let alloc = unsafe { talc.allocate(layout) };
+        let grown = memory_pages() - before;
+
+        assert!(alloc.is_some(), "seed {seed}: 1-page allocation failed");
+        assert!(grown <= 3, "seed {seed}: grew {grown} pages for a 1-page allocation");
+        // the abandoned talc leaks its heaps; fine for a test
+    }
+}
+
+/// Allocation trace captured from a real workload (an authenticated
+/// decryption of a 64 KiB buffer) that grew memory to 4 GiB under
+/// `WasmGrowAndClaim`. Ops are (kind, a, b): 1 = alloc(size, align),
+/// 2 = dealloc(size, align) of the most recent matching allocation,
+/// 3 = realloc(old_size, new_size).
+#[wasm_bindgen_test]
+fn grow_and_claim_replayed_decrypt_trace_terminates() {
+    const TRACE: &[(u8, usize, usize)] = &[
+        (1, 65536, 1),
+        (1, 12, 1),
+        (1, 32, 1),
+        (1, 1, 1),
+        (1, 16, 1),
+        (1, 16, 1),
+        (1, 4, 4),
+        (1, 12, 4),
+        (1, 1, 1),
+        (2, 4, 4),
+        (1, 8, 1),
+        (3, 8, 16),
+        (1, 8, 1),
+        (3, 8, 16),
+        (1, 42, 1),
+        (2, 42, 1),
+        (1, 18, 1),
+        (1, 65520, 1),
+        (1, 65520, 1),
+        (2, 65520, 1),
+        (1, 12, 4),
+        (2, 65520, 1),
+        (2, 18, 1),
+        (1, 33, 1),
+        (2, 12, 4),
+        (2, 16, 1),
+        (2, 16, 1),
+        (2, 1, 1),
+        (2, 12, 4),
+        (2, 16, 1),
+        (2, 16, 1),
+        (2, 1, 1),
+        (2, 32, 1),
+        (2, 12, 1),
+        (2, 65536, 1),
+        (1, 10, 1),
+        (3, 10, 43),
+        (2, 43, 1),
+        (1, 60, 8),
+        (2, 33, 1),
+    ];
+
+    let cell = TalcCell::<_, WasmBinning>::new(WasmGrowAndClaim);
+    let mut live: Vec<(*mut u8, Layout)> = Vec::new();
+
+    for (i, &(kind, a, b)) in TRACE.iter().enumerate() {
+        let before = memory_pages();
+        match kind {
+            1 => {
+                let layout = Layout::from_size_align(a, b).unwrap();
+                let ptr = unsafe { cell.alloc(layout) };
+                assert!(!ptr.is_null(), "op {i}: alloc({a},{b}) failed");
+                live.push((ptr, layout));
+            }
+            2 => {
+                let layout = Layout::from_size_align(a, b).unwrap();
+                let at = live.iter().rposition(|&(_, l)| l == layout).unwrap();
+                let (ptr, layout) = live.remove(at);
+                unsafe { cell.dealloc(ptr, layout) };
+            }
+            _ => {
+                let at = live.iter().rposition(|&(_, l)| l.size() == a).unwrap();
+                let (ptr, layout) = live.remove(at);
+                let new_ptr = unsafe { cell.realloc(ptr, layout, b) };
+                assert!(!new_ptr.is_null(), "op {i}: realloc({a},{b}) failed");
+                live.push((new_ptr, Layout::from_size_align(b, layout.align()).unwrap()));
+            }
+        }
+        let grown = memory_pages() - before;
+        let requested_pages = (a.max(b) + 65535) / 65536;
+        assert!(grown <= requested_pages + 2, "op {i} ({kind},{a},{b}): grew {grown} pages");
+    }
+}
+
+/// Extending a heap whose top gap is at least 16 MiB must fuse the gap
+/// rather than corrupt it: `end_to_tag` used to read the most significant
+/// byte of the gap's trailing size, misclassifying gaps with bit 24 set as
+/// allocated chunks and corrupting their recorded size.
+#[wasm_bindgen_test]
+fn extend_fuses_large_top_gap() {
+    let cell = TalcCell::<_, WasmBinning>::new(WasmGrowAndExtend::new());
+
+    // leave a ~24 MiB top gap (bit 24 set in its size)
+    let big = Layout::from_size_align(0x180_0000, 1).unwrap();
+    let a = unsafe { cell.alloc(big) };
+    assert!(!a.is_null());
+    unsafe { cell.dealloc(a, big) };
+
+    // doesn't fit: forces acquire → memory.grow → extend over the top gap
+    let bigger = Layout::from_size_align(0x200_0000, 1).unwrap();
+    let b = unsafe { cell.alloc(bigger) };
+    assert!(!b.is_null());
+    fill(b, bigger.size(), 0x5a);
+    verify(b, bigger.size(), 0x5a);
+    unsafe { cell.dealloc(b, bigger) };
+
+    // exercises another scan over the (previously corrupted) gap lists
+    let small = Layout::from_size_align(64, 1).unwrap();
+    let c = unsafe { cell.alloc(small) };
+    assert!(!c.is_null());
+    unsafe { cell.dealloc(c, small) };
+}
+
+/// Random alloc/dealloc/realloc actions with content verification against
+/// `WasmGrowAndExtend`, driven through `TalcCell`'s `GlobalAlloc` like a
+/// global allocator would be.
+#[wasm_bindgen_test]
+fn grow_and_extend_random_actions_preserve_contents() {
+    let cell = TalcCell::<_, WasmBinning>::new(WasmGrowAndExtend::new());
+    let mut rng = Lcg(0x5eed_1234_abcd_ef01);
+    let mut slots: Vec<(*mut u8, Layout, u8)> = Vec::with_capacity(2048);
+    let mut live = 0usize;
+
+    for _ in 0..30_000 {
+        while live > 48 * 1024 * 1024 {
+            let (ptr, layout, pattern) = slots.swap_remove(rng.below(slots.len() as u64) as usize);
+            verify(ptr, layout.size(), pattern);
+            unsafe { cell.dealloc(ptr, layout) };
+            live -= layout.size();
+        }
+
+        match rng.below(100) {
+            0..=44 => {
+                let layout = random_layout(&mut rng);
+                let pattern = (rng.next() & 0xff) as u8;
+                let ptr = unsafe { cell.alloc(layout) };
+                assert!(!ptr.is_null(), "allocation of {layout:?} failed");
+                fill(ptr, layout.size(), pattern);
+                live += layout.size();
+                slots.push((ptr, layout, pattern));
+            }
+            45..=74 if !slots.is_empty() => {
+                let (ptr, layout, pattern) =
+                    slots.swap_remove(rng.below(slots.len() as u64) as usize);
+                verify(ptr, layout.size(), pattern);
+                unsafe { cell.dealloc(ptr, layout) };
+                live -= layout.size();
+            }
+            75.. if !slots.is_empty() => {
+                let i = rng.below(slots.len() as u64) as usize;
+                let (ptr, layout, pattern) = slots[i];
+                let new_size = (random_layout(&mut rng).size()).max(1);
+                verify(ptr, layout.size(), pattern);
+                let new_ptr = unsafe { cell.realloc(ptr, layout, new_size) };
+                assert!(!new_ptr.is_null(), "realloc to {new_size} failed");
+                verify(new_ptr, layout.size().min(new_size), pattern);
+                fill(new_ptr, new_size, pattern);
+                live = live - layout.size() + new_size;
+                slots[i] =
+                    (new_ptr, Layout::from_size_align(new_size, layout.align()).unwrap(), pattern);
+            }
+            _ => {}
+        }
+    }
+
+    for (ptr, layout, pattern) in slots {
+        verify(ptr, layout.size(), pattern);
+        unsafe { cell.dealloc(ptr, layout) };
+    }
+}
+
+/// Many buffers growing by repeated doubling reallocs, interleaved so that
+/// in-place growth, copying reallocs, and gap coalescing all churn near the
+/// heap top.
+#[wasm_bindgen_test]
+fn grow_and_extend_interleaved_growth_preserves_contents() {
+    let cell = TalcCell::<_, WasmBinning>::new(WasmGrowAndExtend::new());
+    let mut rng = Lcg(0x0ddc_0ffe_e0dd_f00d);
+    let mut pinned: Vec<(*mut u8, Layout, u8)> = Vec::new();
+
+    for _ in 0..48u64 {
+        let mut slots: Vec<(*mut u8, Layout, u8)> = (0..64)
+            .map(|i| {
+                let layout = Layout::from_size_align(8 << (i % 4), 1 << (i % 4)).unwrap();
+                let pattern = (rng.next() & 0xff) as u8;
+                let ptr = unsafe { cell.alloc(layout) };
+                assert!(!ptr.is_null());
+                fill(ptr, layout.size(), pattern);
+                (ptr, layout, pattern)
+            })
+            .collect();
+
+        while slots.iter().any(|(_, layout, _)| layout.size() < 128 * 1024) {
+            let i = rng.below(slots.len() as u64) as usize;
+            let (ptr, layout, pattern) = slots[i];
+            if layout.size() >= 128 * 1024 {
+                continue;
+            }
+            let new_size = layout.size() * 2;
+            verify(ptr, layout.size(), pattern);
+            let new_ptr = unsafe { cell.realloc(ptr, layout, new_size) };
+            assert!(!new_ptr.is_null());
+            verify(new_ptr, layout.size(), pattern);
+            fill(new_ptr, new_size, pattern);
+            slots[i] =
+                (new_ptr, Layout::from_size_align(new_size, layout.align()).unwrap(), pattern);
+        }
+
+        // free most, pin some across rounds to scatter live chunks
+        for (i, (ptr, layout, pattern)) in slots.drain(..).enumerate() {
+            verify(ptr, layout.size(), pattern);
+            if i % 8 == 7 && pinned.len() < 64 {
+                pinned.push((ptr, layout, pattern));
+            } else {
+                unsafe { cell.dealloc(ptr, layout) };
+            }
+        }
+        for &(ptr, layout, pattern) in &pinned {
+            verify(ptr, layout.size(), pattern);
+        }
+    }
+
+    for (ptr, layout, pattern) in pinned {
+        verify(ptr, layout.size(), pattern);
+        unsafe { cell.dealloc(ptr, layout) };
+    }
+}


### PR DESCRIPTION
Hi! Using talc 5.0.3 as the global allocator on wasm32-unknown-unknown in a long-running app, I hit both memory corruption (out-of-bounds traps) and unbounded linear memory growth. I tracked them down to two separate bugs.

1. end_to_tag reads the wrong byte for gaps. Tag is a u8 stored at end - 1, but a gap's trailing size is a usize at end - size_of::<usize>(). On little-endian, reading end - 1 on a gap yields the size's most significant byte. For gaps of 16 MiB+ with bit 24 set, is_allocated() returns true, so extend() misclassifies the top gap as an allocated chunk and Tag::set_above_free flips bit 25 of the stored size, silently adding 0x2000000 to it. From there the gap lists are inconsistent and the allocator hands out overlapping allocations. deallocate()'s below-neighbor check has the same hazard. With error-scanning-std enabled this shows up as the head/tail size assert failing in scan_for_errors.

Fix: the tag now lives in the low byte of the chunk's last word (added TAIL_SIZE in chunk.rs), the same byte where a gap's trailing size keeps its always-zero low bits, so allocations and gaps stay distinguishable for any gap size. Costs up to size_of::<usize>() - 1 extra bytes per chunk.

2. WasmGrowAndClaim/WasmGrowAndExtend undersize their memory.grow. acquire computes delta_pages from layout.size() + CHUNK_UNIT, but the new heap actually needs required_chunk_size(layout.size()) plus claim overhead. For sizes just below a page multiple (e.g. 65520 = 65536 - 16, which is exactly what an AES-GCM decrypt of a 64 KiB buffer allocates), the claimed heap can never fit the allocation, so allocate() keeps calling acquire until memory.grow fails at the 4 GiB limit. I measured 65k+ claimed heaps from a single 64 KiB allocation before the allocation finally failed. Fix: delta_pages_for() sizes the growth from required_chunk_size + CHUNK_UNIT, plus the alignment when it exceeds CHUNK_UNIT.

Both are covered by regression tests in talc/tests/wasm_sources.rs, which run on wasm32 via wasm-bindgen-test (command in the file header). They include a minimal deterministic repro for each bug, an allocation-trace replay captured from the real workload that triggered the runaway, and randomized alloc/dealloc/realloc tests with content verification. Without the fixes, extend_fuses_large_top_gap fails on the scan_for_errors size assert and the grow_and_claim tests hang growing to 4 GiB; with them, everything passes (native suite included).

Note: Cargo.lock includes a wasm-bindgen bump, needed so the tests run with a current wasm-bindgen-cli runner. Happy to drop it from the PR if you'd rather keep the lockfile as is.