### PR TITLE
Document the chunk/tag memory layout and assert its discriminator invariants

### DIFF
--- a/talc/src/base/chunk.rs
+++ b/talc/src/base/chunk.rs
@@ -1,6 +1,20 @@
-//! A bunch of utility functions for working with chunks.
+//! Chunk layout helpers and the constants that define it.
 //!
+//! A heap is a contiguous run of chunks, each `[base, end)` with base and size
+//! aligned to `CHUNK_UNIT`. The last word, `[end - TAIL_SIZE, end)`, is a
+//! metadata slot the upper neighbour reads (via `end_to_tag`) to classify it:
 //!
+//! - **Allocated:** caller data in `[base, ..)`, with the [`Tag`] in that word
+//!   (low bits = flags). `required_chunk_size` reserves it so data can't reach it.
+//! - **Gap (≥ `CHUNK_UNIT` = 4 words):** the intrusive `Node` (2 words), a bin
+//!   index (`u32`), and its size as a boundary tag at both `base + 3 words` and
+//!   the trailing word (they coincide for a minimal gap).
+//!
+//! To tell the two apart Talc reads that trailing word and tests `ALLOCATED`. A
+//! gap's `CHUNK_UNIT`-aligned size has zero low bits (where every flag lives),
+//! while an allocation sets the bit. Reading the whole word as a `usize` keeps
+//! this independent of byte order; a byte-sized read would only hold on
+//! little-endian.
 
 use core::{mem::size_of, ptr::NonNull};
 
@@ -27,15 +41,24 @@ pub(crate) unsafe fn alloc_to_end(base: *mut u8, size: usize) -> *mut u8 {
 /// It may situationally take on other values in the future.
 pub const CHUNK_UNIT: usize = size_of::<usize>() * 4;
 
-/// Every chunk ends in a word-sized metadata slot: allocated chunks keep
-/// their [`Tag`] in its low byte, gaps fill it with their size and flags.
-/// A gap size's low bits are always zero, so the low byte distinguishes
-/// allocations from gaps no matter how large the gap is.
+/// The trailing metadata word of every chunk: an allocation's [`Tag`] or a gap's
+/// size. A gap size is `CHUNK_UNIT`-aligned, so reading this word as a `usize`
+/// and testing the low (flag) bits tells the two apart on any endianness.
 pub(crate) const TAIL_SIZE: usize = size_of::<usize>();
+
+// The discriminator (and packing END_FLAG into a gap's size) needs CHUNK_UNIT to
+// be a power of two and every Tag flag to fit in the low bits that are always
+// zero in a CHUNK_UNIT-aligned size.
+const _: () = assert!(CHUNK_UNIT.is_power_of_two());
+const _: () = assert!(
+    (Tag::ALLOCATED_FLAG | Tag::ABOVE_FREE_FLAG | Tag::HEAP_BASE_FLAG | Tag::HEAP_END_FLAG)
+        < CHUNK_UNIT,
+);
 
 const GAP_NODE_OFFSET: usize = 0;
 const GAP_BIN_OFFSET: usize = size_of::<usize>() * 2;
 const GAP_LOW_SIZE_OFFSET: usize = size_of::<usize>() * 3;
+/// Trailing boundary-tag size, at `end - TAIL_SIZE` (the discriminator slot).
 const GAP_HIGH_SIZE_OFFSET: usize = TAIL_SIZE;
 
 pub const END_FLAG: usize = Tag::HEAP_END_FLAG as usize;

--- a/talc/src/base/tag.rs
+++ b/talc/src/base/tag.rs
@@ -1,4 +1,13 @@
-//! A `Tag` just above every allocation and contains a number of bits for the allocation algorithm.
+//! The metadata word at the end of every chunk: an allocation's flag bits, or a
+//! gap's size.
+//!
+//! Talc tells them apart by testing [`Tag::ALLOCATED_FLAG`]: a gap's size is
+//! `CHUNK_UNIT`-aligned so its low (flag) bits are zero, while an allocation sets
+//! `ALLOCATED`. `Tag` wraps a `usize` so the test reads the whole word as an
+//! integer, independent of byte order. A `u8` would, on big-endian, land on the
+//! high byte of a large gap's size instead of the always-zero low bits.
+//!
+//! See `crate::base::chunk` for the full layout.
 
 /// Tag for allocated chunk metadata.
 #[derive(Clone, Copy)]


### PR DESCRIPTION
Follow-up to #49 / v5.0.4. Moving `Tag` to `usize` left a `// TODO document the memory layout well` in the source wrappers, so this is a pass at exactly that: it documents the chunk/gap layout the tag and dynamic-heap code lean on, plus two asserts that pin the invariant down. Docs and `const` asserts only, no behavior or API change.

The `base/chunk.rs` module docs now lay out the allocated and gap cases (the trailing metadata word, the free-chunk fields, how `required_chunk_size` reserves that word) and say *why* the gap/allocation discriminator is unambiguous: a gap's `CHUNK_UNIT`-aligned size has zero low bits where the flags live, and reading the whole word as a `usize` is what makes that endianness-independent, which is the reasoning behind v5.0.4. I also fixed the `TAIL_SIZE` doc that still said "low byte". `base/tag.rs` gets the same from the tag's side.

The two asserts encode what the discriminator depends on so it can't quietly break later: the second one stops compiling if a flag bit ever lands at or above `CHUNK_UNIT`'s alignment, where it'd start aliasing a gap size and clobbering `END_FLAG`.

I wrote it the way I read the code, so please correct anything that's off; you know the design best. `cargo check`, the unit and doc tests, and `cargo doc` under `-D warnings` all pass.
